### PR TITLE
Removed keptn versions < 0.18.x

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.16.0", "0.17.0", "0.18.1", "0.19.0"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.18.1", "0.19.0"] # https://github.com/keptn/keptn/releases
         datadog-version: ["2.37.2"] # chart version
     env:
       GO_VERSION: 1.17


### PR DESCRIPTION
Removed 0.16.x , 0.17.x versions of keptn from the workflow/integration-tests.yaml. 