### PR TITLE
fix:Removed keptn versions < 0.18.x

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.16.0", "0.17.0", "0.18.1", "0.19.0"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.18.1", "0.19.0"] # https://github.com/keptn/keptn/releases
         datadog-version: ["2.37.2"] # chart version
     env:
       GO_VERSION: 1.17


### PR DESCRIPTION
Removed keptn versions 0.16.x , 0.17.x from workflow/integration-tests.yaml file
![Screenshot from 2022-10-07 12-40-41](https://user-images.githubusercontent.com/90996971/194519078-5b490ab1-2996-406b-b663-515c3e955b6f.png)

I have run the integration test myself and found no bugs.

Signed-off-by: TarangVerma <tarangverma004@gmail.com>