### PR TITLE
docs:Added more info to readme.md 

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.16.0", "0.17.0", "0.18.1", "0.19.0"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.18.1", "0.19.0"] # https://github.com/keptn/keptn/releases
         datadog-version: ["2.37.2"] # chart version
     env:
       GO_VERSION: 1.17

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Check [the official docs](https://docs.datadoghq.com/account_management/api-app-
 Note: Application keys get the same permissions as you. You might want to narrow down the permissions (datadog-service only reads metrics from the API. Check the official docs linked above for more information).
 
 ## If you already have a Keptn cluster running
+Note: Before installing datadog add this repo to your working directory
+```bash
+helm repo add datadog https://helm.datadoghq.com
+```
 1. Install datadog
 ```bash
 export DD_API_KEY="<your-datadog-api-key>" DD_APP_KEY="<your-datadog-app-key>" DD_SITE="datadoghq.com" 


### PR DESCRIPTION
The current docs do not include adding the helm repo before installing datadog which was little bit confusing to beginners.